### PR TITLE
Registration schema changes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure(2) do |config|
     virtualenv --always-copy -p python2 .
     . bin/activate
     pip install -r requirements.txt
+    pip install -r requirements-dev.txt
     python seed_qa_keys.py
   SHELL
 end

--- a/schemas/rcs_reg_schema_v2_0_0.json
+++ b/schemas/rcs_reg_schema_v2_0_0.json
@@ -25,17 +25,17 @@
             "required": [ "service_url" ]
         },
 
-        "serviceNode": {
+        "service_node": {
             "oneOf": [
-                { "$ref": "#/defs/basicNode" },
-                { "$ref": "#/defs/featureNode" },
-                { "$ref": "#/defs/imageryNode" },
-                { "$ref": "#/defs/wmsNode" },
-                { "$ref": "#/defs/dynamicNode" }
+                { "$ref": "#/defs/basic_node" },
+                { "$ref": "#/defs/feature_node" },
+                { "$ref": "#/defs/imagery_node" },
+                { "$ref": "#/defs/wms_node" },
+                { "$ref": "#/defs/dynamic_node" }
             ]
         },
 
-        "basicNode": {
+        "basic_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string" },
@@ -46,7 +46,7 @@
             "additionalProperties": false
         },
 
-        "featureNode": {
+        "feature_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string", "description": "The service endpoint URL" },
@@ -55,14 +55,14 @@
                 "service_type": { "type": "string", "enum": ["esriFeature"], "description": "Service type of the endpoint" },
                 "display_field": { "type": "string", "description": "Default attribute for identifying features" },
                 "loading_mode": { "type": "string", "enum": ["ondemand","snapshot"], "description": "Specifies the layer loading mode: either snapshot (load all data upfront) or ondemand (load data as needed); when not specified RCS will probe the service and make an intelligent guesss" },
-                "max_allowable_offset": { "type": "integer", "minimum": 0, "description": "Simplification factor for the layer geometry" },
-                "tolerance": { "type": "integer", "minimum": 0, "description": "Tolerance (in pixels) of feature queries" }
+                "max_allowable_offset": { "type": "integer", "minimum": 0, "description": "Simplification factor for the layer geometry; may be omitted in which case no value will be provided in the output leaving the viewer to apply its own logic." },
+                "tolerance": { "type": "integer", "minimum": 0, "default": 5, "description": "Tolerance (in pixels) of feature queries" }
             },
             "required": [ "service_url", "service_type" ],
             "additionalProperties": false
         },
 
-        "imageryNode": {
+        "imagery_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string", "description": "The service endpoint URL" },
@@ -74,14 +74,14 @@
             "additionalProperties": false
         },
 
-        "wmsNode": {
+        "wms_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string", "description": "The service endpoint URL" },
                 "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
                 "metadata": { "$ref": "#/defs/metadata" },
                 "service_type": { "type": "string", "enum": ["ogcWms"], "description": "Service type of the endpoint" },
-                "scrape_only": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 },
+                "scrape_only": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1, "description": "If specified it indicates which Layer entries should be scraped by the RCS; all Layers should be identfied by their Name element.  When it is omitted RCS will attempt to scrape all Layer elements containing a Name entry." },
                 "legend_format": { "type": "string" },
                 "feature_info_format": { "type": "string", "enum": [ "text/html;fgpv=summary", "text/html", "text/plain", "application/json" ], "description": "If specified indicates that GetFeatureInfo should be enabled for this WMS and indicates the format that should be requested." }
             },
@@ -89,14 +89,14 @@
             "additionalProperties": false
         },
 
-        "dynamicNode": {
+        "dynamic_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string", "description": "The service endpoint URL" },
                 "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
                 "metadata": { "$ref": "#/defs/metadata" },
                 "service_type": { "type": "string", "enum": ["esriDynamic"], "description": "Service type of the endpoint" },
-                "scrape_only": { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1 }
+                "scrape_only": { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1, "description": "If specified it indicates which indexes should be scraped by the RCS.  When it is omitted RCS will attempt to scrape all indexes within the endpoint." }
             },
             "required": [ "service_url", "service_type" ],
             "additionalProperties": false
@@ -106,8 +106,8 @@
 
     "properties": {
         "version": { "type": "string", "enum": [ "2.0" ] },
-        "en": {"$ref": "#/defs/serviceNode"},
-        "fr": {"$ref": "#/defs/serviceNode"}
+        "en": {"$ref": "#/defs/service_node"},
+        "fr": {"$ref": "#/defs/service_node"}
     },
     "required": ["version", "en", "fr"],
     "additionalProperties": false

--- a/schemas/rcs_reg_schema_v2_0_0.json
+++ b/schemas/rcs_reg_schema_v2_0_0.json
@@ -29,7 +29,9 @@
             "oneOf": [
                 { "$ref": "#/defs/basicNode" },
                 { "$ref": "#/defs/featureNode" },
-                { "$ref": "#/defs/wmsNode" }
+                { "$ref": "#/defs/imageryNode" },
+                { "$ref": "#/defs/wmsNode" },
+                { "$ref": "#/defs/dynamicNode" }
             ]
         },
 
@@ -47,32 +49,56 @@
         "featureNode": {
             "type": "object",
             "properties": {
-                "service_url": { "type": "string" },
-                "service_name": { "type": "string" },
+                "service_url": { "type": "string", "description": "The service endpoint URL" },
+                "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
                 "metadata": { "$ref": "#/defs/metadata" },
-                "service_type": { "type": "string", "enum": ["esriFeature"] },
-                "display_field": { "type": "string" },
+                "service_type": { "type": "string", "enum": ["esriFeature"], "description": "Service type of the endpoint" },
+                "display_field": { "type": "string", "description": "Default attribute for identifying features" },
                 "loading_mode": { "type": "string", "enum": ["ondemand","snapshot"], "description": "Specifies the layer loading mode: either snapshot (load all data upfront) or ondemand (load data as needed); when not specified RCS will probe the service and make an intelligent guesss" },
-                "max_allowable_offset": { "type": "integer", "minimum": 0, "description": "Simplification factor for the layer geometry" }
+                "max_allowable_offset": { "type": "integer", "minimum": 0, "description": "Simplification factor for the layer geometry" },
+                "tolerance": { "type": "integer", "minimum": 0, "description": "Tolerance (in pixels) of feature queries" }
             },
             "required": [ "service_url", "service_type" ],
             "additionalProperties": false
         },
 
-
-        "wmsNode": {
-            "$ref": "#/defs/service",
+        "imageryNode": {
             "type": "object",
             "properties": {
-                "service_url": { "type": "string" },
-                "service_name": { "type": "string" },
+                "service_url": { "type": "string", "description": "The service endpoint URL" },
+                "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
                 "metadata": { "$ref": "#/defs/metadata" },
-                "service_type": { "type": "string", "enum": ["ogcWms"] },
-                "layer_id": { "type": "string" },
-                "legend_format": { "type": "string" },
-                "feature_info_type": { "type": "string" }
+                "service_type": { "type": "string", "enum": ["esriTile", "esriImage"], "description": "Service type of the endpoint" }
             },
-            "required": [ "service_url", "service_type", "layer_id" ],
+            "required": [ "service_url", "service_type" ],
+            "additionalProperties": false
+        },
+
+        "wmsNode": {
+            "type": "object",
+            "properties": {
+                "service_url": { "type": "string", "description": "The service endpoint URL" },
+                "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
+                "metadata": { "$ref": "#/defs/metadata" },
+                "service_type": { "type": "string", "enum": ["ogcWms"], "description": "Service type of the endpoint" },
+                "scrape_only": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 },
+                "legend_format": { "type": "string" },
+                "feature_info_format": { "type": "string", "enum": [ "text/html;fgpv=summary", "text/html", "text/plain", "application/json" ], "description": "If specified indicates that GetFeatureInfo should be enabled for this WMS and indicates the format that should be requested." }
+            },
+            "required": [ "service_url", "service_type" ],
+            "additionalProperties": false
+        },
+
+        "dynamicNode": {
+            "type": "object",
+            "properties": {
+                "service_url": { "type": "string", "description": "The service endpoint URL" },
+                "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
+                "metadata": { "$ref": "#/defs/metadata" },
+                "service_type": { "type": "string", "enum": ["esriDynamic"], "description": "Service type of the endpoint" },
+                "scrape_only": { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1 }
+            },
+            "required": [ "service_url", "service_type" ],
             "additionalProperties": false
         }
 

--- a/schemas/rcs_reg_schema_v2_0_0.json
+++ b/schemas/rcs_reg_schema_v2_0_0.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "title": "RCS Schema",
-    "description": "An RCS request object",
+    "description": "An RCS registration request",
     "version": "2.0.0",
 
     "defs": {
@@ -30,8 +30,8 @@
                 { "$ref": "#/defs/basic_node" },
                 { "$ref": "#/defs/feature_node" },
                 { "$ref": "#/defs/imagery_node" },
-                { "$ref": "#/defs/wms_node" },
-                { "$ref": "#/defs/dynamic_node" }
+                { "$ref": "#/defs/ogc_node" },
+                { "$ref": "#/defs/esri_map_node" }
             ]
         },
 
@@ -74,14 +74,15 @@
             "additionalProperties": false
         },
 
-        "wms_node": {
+        "ogc_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string", "description": "The service endpoint URL" },
                 "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
                 "metadata": { "$ref": "#/defs/metadata" },
-                "service_type": { "type": "string", "enum": ["ogcWms"], "description": "Service type of the endpoint" },
+                "service_type": { "type": "string", "enum": ["ogcWms", "ogcWmts"], "description": "Service type of the endpoint" },
                 "scrape_only": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1, "description": "If specified it indicates which Layer entries should be scraped by the RCS; all Layers should be identfied by their Name element.  When it is omitted RCS will attempt to scrape all Layer elements containing a Name entry." },
+                "recursive": { "type": "boolean", "default": false, "description": "Indicates if children should be scraped by the RCS and may be made available as individual layers to the viewer (the endpoints necessary will not be available with the release of the new RCS)."},
                 "legend_format": { "type": "string" },
                 "feature_info_format": { "type": "string", "enum": [ "text/html;fgpv=summary", "text/html", "text/plain", "application/json" ], "description": "If specified indicates that GetFeatureInfo should be enabled for this WMS and indicates the format that should be requested." }
             },
@@ -89,14 +90,15 @@
             "additionalProperties": false
         },
 
-        "dynamic_node": {
+        "esri_map_node": {
             "type": "object",
             "properties": {
                 "service_url": { "type": "string", "description": "The service endpoint URL" },
                 "service_name": { "type": "string", "description": "Name of the service endpoint, used for display" },
                 "metadata": { "$ref": "#/defs/metadata" },
-                "service_type": { "type": "string", "enum": ["esriDynamic"], "description": "Service type of the endpoint" },
-                "scrape_only": { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1, "description": "If specified it indicates which indexes should be scraped by the RCS.  When it is omitted RCS will attempt to scrape all indexes within the endpoint." }
+                "service_type": { "type": "string", "enum": ["esriMapServer", "esriFeatureServer"], "description": "Service type of the endpoint" },
+                "scrape_only": { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1, "description": "If specified it indicates which indexes should be scraped by the RCS.  When it is omitted RCS will attempt to scrape all indexes within the endpoint." },
+                "recursive": { "type": "boolean", "default": false, "description": "Indicates if children should be scraped by the RCS and may be made available as individual layers to the viewer (the endpoints necessary will not be available with the release of the new RCS)."}
             },
             "required": [ "service_url", "service_type" ],
             "additionalProperties": false

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,8 +1,8 @@
 import pytest, services.regparse.metadata as md
 
-config_1 = {'METADATA_URL': 'http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap?version=1.3.0&request=getcapabilities&service={0}', 'CATALOGUE_URL': 'http://www.google.ca/'}  # NOQA
-config_2 = {'METADATA_URL': 'http://nowhere.example.com/{0}', 'CATALOGUE_URL': "{0}"}
-valid_url = {'metadata': {'metadata_url': 'http://www2.dmsolutions.ca/cgi-bin/mswfs_gmap?version=1.3.0&request=getcapabilities&service=wms', 'catalogue_url': 'http://www.google.ca/'}}  # NOQA
+config_1 = {'METADATA_URL': 'http://example.com/mswfs_gmap?version=1.3.0&request=getcapabilities&service={0}', 'CATALOGUE_URL': 'http://www.google.ca/'}  # NOQA
+config_2 = {'METADATA_URL': 'http://example.com/{0}', 'CATALOGUE_URL': '{0}'}
+valid_url = {'metadata': {'metadata_url': 'http://example.com/mswfs_gmap?version=1.3.0&request=getcapabilities&service=wms', 'catalogue_url': 'http://www.google.ca/'}}  # NOQA
 valid_uuid = {'metadata': {'uuid': 'wms'}}
 
 


### PR DESCRIPTION
Opened for discussion regarding the new registration format with data catalogue.

RCS will accept WMS and dynamic layers, and if no additional info is provided it will attempt to scrape all available entries within the endpoint (all layer tags in a WMS and all indexes within a MapServer endpoint).

Sample registration of a single index within a layer:
```js
{
  "version": "2.0",
  "en": { "service_url": "" },
  "fr": {
    "service_url": "http://localhost/MapServer",
    "service_type": "esriDynamic",
    "scrape_only": [5]
  }
}
```

Sample registration of all indexes within a compound layer:
```js
{
  "version": "2.0",
  "en": { "service_url": "" },
  "fr": {
    "service_url": "http://localhost/MapServer",
    "service_type": "esriDynamic"
  }
}
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/rcs/13)
<!-- Reviewable:end -->
