### PR TITLE
fix(rcs): service_name not copying when upgrading v1 record to v2

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -6,13 +6,13 @@ RAMP Configuration Service
    :target: https://gitter.im/fgpv-vpgf/rcs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 The RAMP Configuration Service (RCS) is a web service designed to work with the
-Reusable Accessible Mapping Platform `(RAMP) <http://ramp-pcar.github.io>`_ to support
+Reusable Accessible Mapping Platform `(RAMP) <http://fgpv-vpgf.github.io/>`_ to support
 loading of map layers from data catalogues.
 
 RCS as a cache between data catalogues and the RAMP client application.  It will
-prefetch data from certain endpoints and store them as configuration fragments
+pre-fetch data from certain endpoints and store them as configuration fragments
 which the RAMP client can consume.  It is implemented as a REST service in
 Python with a fairly minimal store and retrieve API.
 
-RCS is developed by Environment Canada as part of the RAMP project and is licensed
+RCS is developed by Environment and Climate Change Canada as part of the RAMP project and the Federal Geospatial Platform and is licensed
 under the MIT license.

--- a/services/regparse/universal.py
+++ b/services/regparse/universal.py
@@ -121,6 +121,9 @@ def make_node(key, json_request, config):
             raise ServiceEndpointException(msg)
         n['url'] = json_request[lang]['service_url']
         m_url, c_url = metadata.get_url(json_request[lang], config)
+        if n['url'].endswith("FeatureServer"):
+            msg = 'FeatureServer registration must specify a feature layer'
+            raise ServiceEndpointException(msg)
         if c_url:
             node[lang]['metadataUrl'] = m_url
             node[lang]['catalogueUrl'] = c_url

--- a/services/upgrade.py
+++ b/services/upgrade.py
@@ -5,7 +5,7 @@ from flask.ext.restful import Resource
 
 
 def wms_upgrade(v1_request):
-    steal_fields = ['service_url', 'metadata', 'legend_format']
+    steal_fields = ['service_url', 'service_name', 'metadata', 'legend_format']
     result = {x: v1_request[x] for x in steal_fields if x in v1_request}
     result['service_type'] = regparse.ServiceTypes.WMS
     fi_type = v1_request.get('feature_info_type')
@@ -16,7 +16,7 @@ def wms_upgrade(v1_request):
 
 
 def feat_upgrade(v1_request):
-    steal_fields = ['service_url', 'metadata', 'loading_mode', 'max_allowable_offset', 'display_field']
+    steal_fields = ['service_url', 'metadata', 'loading_mode', 'max_allowable_offset', 'display_field', 'service_name']
     result = {x: v1_request[x] for x in steal_fields if x in v1_request}
     result['service_type'] = regparse.ServiceTypes.FEATURE
     return result

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ del os.link
 setup(
     name="rcs",
     description="RAMP Configuration Service",
-    version="2.1.0",
+    version="2.1.1",
     author="Environment and Climate Change Canada",
     author_email="mike.weech@canada.ca",
     url="https://github.com/fgpv-vpgf/rcs",


### PR DESCRIPTION
Upgrading a version 1 record to version 2 was not copying the service_name attribute to the upgraded record for WMS and feature layers. 

Closes #56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/rcs/57)
<!-- Reviewable:end -->
